### PR TITLE
arm64: DT: kugo: Fix bluesleep

### DIFF
--- a/arch/arm/boot/dts/qcom/msm8956-loire-kugo-common.dtsi
+++ b/arch/arm/boot/dts/qcom/msm8956-loire-kugo-common.dtsi
@@ -137,22 +137,20 @@
 		compatible = "qcom,bluesleep";
 		bt_host_wake = <&msm_gpio 17 0x00>; /* BT_HOST_WAKE */
 		bt_ext_wake = <&msm_gpio 27 0x00>; /* BT_DEV_WAKE */
-		bt_reg_on = <&msm_gpio 36 0x00>; /* BT_REG_ON */
 		interrupt-parent = <&msm_gpio>;
 		interrupts = <17 0>;
 		interrupt-names = "host_wake";
 		pinctrl-names = "default", "sleep";
-		pinctrl-0 = <&msm_gpio_36_def &msm_gpio_17_act &msm_gpio_27_def>;
-		pinctrl-1 = <&msm_gpio_36_def &msm_gpio_17_sus &msm_gpio_27_def>;
+		pinctrl-0 = <&msm_gpio_17_act &msm_gpio_27_def>;
+		pinctrl-1 = <&msm_gpio_17_sus &msm_gpio_27_def>;
 	};
 
 	bcm43xx {
 		compatible = "bcm,bcm43xx";
-		gpios = <&msm_gpio 36 0x00>, /* BT_REG_ON */
-			<&msm_gpio 27 0x00>; /* BT_DEV_WAKE */
+		bcm,reg-on-gpio = <&msm_gpio 36 0x00>; /* BT_REG_ON */
 		pinctrl-names = "default", "sleep";
-		pinctrl-0 = <&msm_gpio_36_def &msm_gpio_27_def>;
-		pinctrl-1 = <&msm_gpio_36_def &msm_gpio_27_def>;
+		pinctrl-0 = <&msm_gpio_36_def>;
+		pinctrl-1 = <&msm_gpio_36_def>;
 	};
 
 	qcom,sensor-information {


### PR DESCRIPTION
Those DT entries are present in loire-common already.
But the gpios are different a bit.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: Ie06527f3c0423dae07aa8fe6857c2afed7bc77cb